### PR TITLE
Fixed performance of SingleXYZColorModel

### DIFF
--- a/jmist-core/src/main/java/ca/eandb/jmist/framework/color/xyz/single/SingleXYZColorModel.java
+++ b/jmist-core/src/main/java/ca/eandb/jmist/framework/color/xyz/single/SingleXYZColorModel.java
@@ -61,7 +61,7 @@ public final class SingleXYZColorModel implements ColorModel {
    * Gets the single instance of this <code>ColorModel</code>.
    * @return The single instance of this <code>ColorModel</code>.
    */
-  public synchronized static SingleXYZColorModel getInstance() {
+  public static SingleXYZColorModel getInstance() {
     return instance;
   }
 


### PR DESCRIPTION
Hi Brad,

The `getInstance()` of other ColorModels like RGBColorModel and XYZColorModel aren't synchronized either so I don't think it's nessesary.

My 4 thread workers were unnaffected but my 8 thread worker was runing at 60% and my 16 at only 32% total cpu usage.
Also verified with some thread dumps with a local ParallelizableJobRunner, seeing on average 50% of the threads asleep on the synchronize.